### PR TITLE
feat: add default toast error handling

### DIFF
--- a/src/utils/asyncAction.js
+++ b/src/utils/asyncAction.js
@@ -50,9 +50,11 @@ export const asyncAction = (
           type: actionNames.error,
           payload: error?.response?.data ?? error?.message,
         });
-        onError
-          ? onError(error)
-          : console.error(error?.response?.data?.message ?? error?.message);
+        if (onError) {
+          onError(error);
+        } else {
+          toast.error(error?.response?.data?.message ?? error?.message);
+        }
       }
       console.log(error);
     }


### PR DESCRIPTION
## Summary
- show default error toast in asyncAction when API calls fail

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find an eslint.config.* file)

------
https://chatgpt.com/codex/tasks/task_e_68c016bec0e48323b319a44d64adbb94